### PR TITLE
Fixed a bug where the session id is missing

### DIFF
--- a/webchat/index.html
+++ b/webchat/index.html
@@ -279,6 +279,7 @@
             if (msg) {
                 socket.emit('user_uttered', {
                     "message": msg,
+                    "session_id": socket.id,
                 });
                 messageInput.value = '';
 
@@ -288,6 +289,7 @@
 
         socket.on('connect', function () {
             console.log("Connected to Socket.io server");
+            console.log("Session ID: ", socket.id);
         });
 
         socket.on('connect_error', (error) => {


### PR DESCRIPTION
- [x] Added session ID to the 'user_uttered event to prevent "UserWarning: A message without a valid session_id was received. This message will be ignored. Make sure to set a proper session id using the `session_request` socketIO event." when there is no valid session ID is present.
- [x] Tested with Rasa 2.8.8